### PR TITLE
Extension Methods to convert Time Quantity to Duration

### DIFF
--- a/docs/modules/kotlin-module.md
+++ b/docs/modules/kotlin-module.md
@@ -73,3 +73,24 @@ You can also multiply and divide with factors:
     val y = 2.0
     val result = x / y // "2m"
     ```
+
+## Geometry
+To calculate the length of a hypothenuse in an right-angled triangle you can use the `pythagoreanTheorem` function.
+```kotlin
+val a: Quantity<Length> = Metre(3)
+val b: Quantity<Length> = Metre(4)
+val c: Quantity<Length> = pythagoreanTheorem(a, b) // = 5m
+```
+
+## Time Quantity
+The Kotlin module allows to convert Time Quantities to Java Durations and the other way around.
+When the Extension methods are imported, a Time Quantity can be converted to a java duration.
+```kotlin
+val quantity: Quantity<Time> = Second(10)
+val duration: Duration = quantity.toDuration()
+```
+Its also possible to create a Time Quantity from a java duration.
+```kotlin
+val duration: Duration = Duration.ofSeconds(10)
+val quantity: Quantity<Time> = duration.toQuantity()
+```

--- a/unit-api-core/src/main/java/com/raynigon/unit_api/core/units/si/SISystemUnitsConstants.java
+++ b/unit-api-core/src/main/java/com/raynigon/unit_api/core/units/si/SISystemUnitsConstants.java
@@ -29,11 +29,7 @@ import com.raynigon.unit_api.core.units.si.speed.KilometrePerHour;
 import com.raynigon.unit_api.core.units.si.speed.MetrePerSecond;
 import com.raynigon.unit_api.core.units.si.temperature.Celsius;
 import com.raynigon.unit_api.core.units.si.temperature.Kelvin;
-import com.raynigon.unit_api.core.units.si.time.Hour;
-import com.raynigon.unit_api.core.units.si.time.MicroSecond;
-import com.raynigon.unit_api.core.units.si.time.MilliSecond;
-import com.raynigon.unit_api.core.units.si.time.Minute;
-import com.raynigon.unit_api.core.units.si.time.Second;
+import com.raynigon.unit_api.core.units.si.time.*;
 import com.raynigon.unit_api.core.units.si.volume.CubicMetre;
 import com.raynigon.unit_api.core.units.si.volume.Litre;
 
@@ -83,6 +79,7 @@ public class SISystemUnitsConstants {
     public static final MilliWattHour MilliWattHour = new MilliWattHour();
     public static final Millimetre Millimetre = new Millimetre();
     public static final Minute Minute = new Minute();
+    public static final NanoSecond NanoSecond = new NanoSecond();
     public static final Newton Newton = new Newton();
     public static final One One = new One();
     public static final Percent Percent = new Percent();
@@ -218,6 +215,10 @@ public class SISystemUnitsConstants {
 
     public static Quantity<Time> MicroSecond(Number value) {
         return quantity(value, MicroSecond);
+    }
+
+    public static Quantity<Time> NanoSecond(Number value) {
+        return quantity(value, NanoSecond);
     }
 
     public static Quantity<Area> SquareMetre(Number value) {

--- a/unit-api-core/src/main/java/com/raynigon/unit_api/core/units/si/time/NanoSecond.java
+++ b/unit-api-core/src/main/java/com/raynigon/unit_api/core/units/si/time/NanoSecond.java
@@ -1,0 +1,13 @@
+package com.raynigon.unit_api.core.units.si.time;
+
+import com.raynigon.unit_api.core.units.general.ScaledUnit;
+
+import javax.measure.MetricPrefix;
+import javax.measure.quantity.Time;
+
+public class NanoSecond extends ScaledUnit<Time> {
+
+  public NanoSecond() {
+    super(MetricPrefix.NANO, new Second(), "NanoSecond");
+  }
+}

--- a/unit-api-kotlin/src/main/kotlin/com/raynigon/unit_api/kotlin/DurationExtension.kt
+++ b/unit-api-kotlin/src/main/kotlin/com/raynigon/unit_api/kotlin/DurationExtension.kt
@@ -9,12 +9,20 @@ import javax.measure.quantity.Time
 import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.NanoSecond as cNanoSecond
 import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.Second as cSecond
 
+/**
+ * Convert a Java Duration to a Time Quantity.
+ * @return the Quantity<Time> object with nano second resolution
+ */
 fun Duration.toQuantity(): Quantity<Time> {
     if (this.nano == 0)
         return cSecond(this.seconds)
     return (cSecond(this.seconds) + cNanoSecond(this.nano))
 }
 
+/**
+ * Convert a Time Quantity to a Java Duration.
+ * @return the Java Duration object with nano second resolution
+ */
 fun Quantity<Time>.toDuration(): Duration {
     val seconds: Long = this.to(Second()).value.toLong()
     val nanos: Long = (this - cSecond(seconds)).to(NanoSecond()).value.toLong()

--- a/unit-api-kotlin/src/main/kotlin/com/raynigon/unit_api/kotlin/DurationExtension.kt
+++ b/unit-api-kotlin/src/main/kotlin/com/raynigon/unit_api/kotlin/DurationExtension.kt
@@ -1,0 +1,23 @@
+package com.raynigon.unit_api.kotlin
+
+import com.raynigon.unit_api.core.units.si.time.NanoSecond
+import com.raynigon.unit_api.core.units.si.time.Second
+import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.NanoSecond as cNanoSecond
+import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.Second as cSecond
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import javax.measure.Quantity
+import javax.measure.quantity.Time
+
+fun Duration.toQuantity(): Quantity<Time> {
+    if (this.nano == 0)
+        return cSecond(this.seconds)
+    return (cSecond(this.seconds) + cNanoSecond(this.nano))
+}
+
+fun Quantity<Time>.toDuration(): Duration {
+    val seconds: Long = this.to(Second()).value.toLong()
+    val nanos: Long = (this - cSecond(seconds)).to(NanoSecond()).value.toLong()
+    return Duration.of(seconds, ChronoUnit.SECONDS)
+        .plus(Duration.of(nanos, ChronoUnit.NANOS))
+}

--- a/unit-api-kotlin/src/main/kotlin/com/raynigon/unit_api/kotlin/DurationExtension.kt
+++ b/unit-api-kotlin/src/main/kotlin/com/raynigon/unit_api/kotlin/DurationExtension.kt
@@ -2,12 +2,12 @@ package com.raynigon.unit_api.kotlin
 
 import com.raynigon.unit_api.core.units.si.time.NanoSecond
 import com.raynigon.unit_api.core.units.si.time.Second
-import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.NanoSecond as cNanoSecond
-import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.Second as cSecond
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import javax.measure.Quantity
 import javax.measure.quantity.Time
+import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.NanoSecond as cNanoSecond
+import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.Second as cSecond
 
 fun Duration.toQuantity(): Quantity<Time> {
     if (this.nano == 0)

--- a/unit-api-kotlin/src/test/kotlin/com/raynigon/unit_api/kotlin/DurationExtensionTest.kt
+++ b/unit-api-kotlin/src/test/kotlin/com/raynigon/unit_api/kotlin/DurationExtensionTest.kt
@@ -1,0 +1,61 @@
+package com.raynigon.unit_api.kotlin
+
+import com.raynigon.unit_api.core.units.si.time.NanoSecond
+import com.raynigon.unit_api.core.units.si.time.Second
+import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.NanoSecond as cNanoSecond
+import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.Second as cSecond
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import java.time.Duration
+
+internal class DurationExtensionTest {
+
+    @Test
+    fun `duration with seconds to quantity`() {
+        val duration = Duration.ofSeconds(10)
+        val quantity = duration.toQuantity()
+
+        assertEquals(10.0, quantity.to(Second()).value.toDouble())
+    }
+
+    @Test
+    fun `quantity seconds to duration`() {
+        val quantity = cSecond(10)
+        val duration = quantity.toDuration()
+
+        assertEquals(Duration.ofSeconds(10), duration)
+    }
+
+    @Test
+    fun `duration with nanoseconds to quantity`() {
+        val duration = Duration.ofNanos(10)
+        val quantity = duration.toQuantity()
+
+        assertEquals(10.0, quantity.to(NanoSecond()).value.toDouble())
+    }
+
+    @Test
+    fun `quantity nanoseconds to duration`() {
+        val quantity = cNanoSecond(10)
+        val duration = quantity.toDuration()
+
+        assertEquals(Duration.ofNanos(10), duration)
+    }
+
+    @Test
+    fun `complex duration to quantity`() {
+        val duration = Duration.ofNanos(10_100_000_000)
+        val quantity = duration.toQuantity()
+
+        assertEquals(10.1, quantity.to(Second()).value.toDouble())
+    }
+
+    @Test
+    fun `complex quantity to duration`() {
+        val quantity = cNanoSecond(10_100_000_000)
+        val duration = quantity.toDuration()
+
+        assertEquals(Duration.ofNanos(10_100_000_000), duration)
+    }
+}

--- a/unit-api-kotlin/src/test/kotlin/com/raynigon/unit_api/kotlin/DurationExtensionTest.kt
+++ b/unit-api-kotlin/src/test/kotlin/com/raynigon/unit_api/kotlin/DurationExtensionTest.kt
@@ -2,12 +2,11 @@ package com.raynigon.unit_api.kotlin
 
 import com.raynigon.unit_api.core.units.si.time.NanoSecond
 import com.raynigon.unit_api.core.units.si.time.Second
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Duration
 import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.NanoSecond as cNanoSecond
 import com.raynigon.unit_api.core.units.si.SISystemUnitsConstants.Second as cSecond
-import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.Assertions.*
-import java.time.Duration
 
 internal class DurationExtensionTest {
 


### PR DESCRIPTION
Fixes #83 

The implementation should be able to convert a java duration to a time quantity. The implementation should be able to convert a time quantity to a java duration.No loss in information is allowed for the conversion. The converted duration has to be accurate for a resolution of one nano second.