### PR TITLE
Handle SQL null values when loading a double value

### DIFF
--- a/spring-boot-jpa-starter/src/main/java/com/raynigon/unit/api/jpa/type/QuantityType.java
+++ b/spring-boot-jpa-starter/src/main/java/com/raynigon/unit/api/jpa/type/QuantityType.java
@@ -103,7 +103,11 @@ public class QuantityType implements UserType<Quantity<?>>, DynamicParameterized
     ) throws SQLException {
         Objects.requireNonNull(unit, "The unit definition is missing");
         if (shape == QuantityShape.NUMBER) {
-            return UnitsApiService.quantity(rs.getDouble(position), unit);
+            double value = rs.getDouble(position);
+            if (rs.wasNull()) {
+                return null;
+            }
+            return UnitsApiService.quantity(value, unit);
         } else if (shape == QuantityShape.NUMERIC_STRING || shape == QuantityShape.STRING) {
             String value = rs.getString(position);
             if (value == null) {

--- a/spring-boot-jpa-starter/src/test/groovy/com/raynigon/unit/api/jpa/JpaStarterApplicationSpec.groovy
+++ b/spring-boot-jpa-starter/src/test/groovy/com/raynigon/unit/api/jpa/JpaStarterApplicationSpec.groovy
@@ -24,7 +24,9 @@ import static com.raynigon.unit.api.core.units.si.SISystemUnitsConstants.Metre
                 "spring.datasource.url=jdbc:tc:postgresql:15:///unitapi",
                 "spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver",
                 "spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect",
-                "spring.jpa.hibernate.ddl-auto=create"
+                "spring.jpa.hibernate.ddl-auto=create",
+                // This is needed to import a multi line sql file...
+                "spring.jpa.properties.hibernate.hbm2ddl.import_files_sql_extractor=org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor"
         ]
 )
 class JpaStarterApplicationSpec extends Specification {
@@ -71,5 +73,6 @@ class JpaStarterApplicationSpec extends Specification {
         result.speed == KilometrePerHour(12)
         result.distance == Kilometre(100)
         result.temperature == Celsius(30)
+        result.power == null
     }
 }

--- a/spring-boot-jpa-starter/src/test/groovy/com/raynigon/unit/api/jpa/helpers/BasicEntity.groovy
+++ b/spring-boot-jpa-starter/src/test/groovy/com/raynigon/unit/api/jpa/helpers/BasicEntity.groovy
@@ -3,6 +3,7 @@ package com.raynigon.unit.api.jpa.helpers
 import com.raynigon.unit.api.core.annotation.QuantityShape
 import com.raynigon.unit.api.core.units.si.length.Kilometre
 import com.raynigon.unit.api.core.units.si.mass.Kilogram
+import com.raynigon.unit.api.core.units.si.power.Watt
 import com.raynigon.unit.api.core.units.si.speed.KilometrePerHour
 import com.raynigon.unit.api.core.units.si.temperature.Celsius
 import com.raynigon.unit.api.jpa.annotation.JpaUnit
@@ -12,6 +13,7 @@ import org.hibernate.annotations.Type
 import javax.measure.Quantity
 import javax.measure.quantity.Length
 import javax.measure.quantity.Mass
+import javax.measure.quantity.Power
 import javax.measure.quantity.Speed
 import javax.measure.quantity.Temperature
 import jakarta.persistence.Column
@@ -46,4 +48,9 @@ class BasicEntity {
     @JpaUnit(unit = Kilogram, shape = QuantityShape.STRING)
     @Column(name = "weight", nullable = true, columnDefinition = "VARCHAR")
     public Quantity<Mass> weight
+
+    @Type(QuantityType.class)
+    @JpaUnit(unit = Watt)
+    @Column(name = "power", nullable = true, columnDefinition = "DOUBLE PRECISION")
+    public Quantity<Power> power
 }

--- a/spring-boot-jpa-starter/src/test/resources/import.sql
+++ b/spring-boot-jpa-starter/src/test/resources/import.sql
@@ -1,2 +1,2 @@
 INSERT INTO basic_entity (id, speed, temperature, distance, weight, power)
-VALUES ('99', 12, 30, 100, '25 kg', null);
+VALUES ('99', 12, 30, 100, '25 kg', NULL);

--- a/spring-boot-jpa-starter/src/test/resources/import.sql
+++ b/spring-boot-jpa-starter/src/test/resources/import.sql
@@ -1,1 +1,2 @@
-INSERT INTO basic_entity (id, speed, temperature, distance, weight) VALUES ('99', 12, 30, 100, '25 kg');
+INSERT INTO basic_entity (id, speed, temperature, distance, weight, power)
+VALUES ('99', 12, 30, 100, '25 kg', null);


### PR DESCRIPTION
The ResultSet returns 0.0 as values, if an SQL null values exists in the requested column. After loading this value, we need to call the "wasNull()" method to check if the value was SQL null or 0.0