### PR TITLE
fix parsing of values with scientific notation

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -80,7 +80,7 @@ jobs:
       - run: pip3 install -r requirements.txt
       - run: mkdocs build -d build/site/
       - name: Upload artifact
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: "Website"
           path: "build/site/"

--- a/unit-api-core/src/main/java/com/raynigon/unit/api/core/io/DefaultQuantityReader.java
+++ b/unit-api-core/src/main/java/com/raynigon/unit/api/core/io/DefaultQuantityReader.java
@@ -9,17 +9,29 @@ import java.util.regex.Pattern;
 
 public class DefaultQuantityReader implements QuantityReader {
 
-    private static final Pattern PATTERN = Pattern.compile("^(-?[.0-9]+\\.?[0-9]*)\\s*(.+)$");
-
     @Override
     public Quantity<?> read(String input) {
         if (input == null) return null;
-        if (input.isEmpty()) return null;
+        if (input.isBlank()) return null;
 
-        Matcher matcher = PATTERN.matcher(input);
-        if (!matcher.matches()) return null;
-        String valueGroup = matcher.group(1);
-        String unitGroup = matcher.group(2);
+        /*
+        Split the input into value and unit.
+        The value part ends either with a number or a dot.
+        The unit part is everything else, trimmed.
+         */
+        int splitPoint = input.length() - 1;
+        for (; splitPoint >= 0; splitPoint--) {
+            char c = input.charAt(splitPoint);
+            if (Character.isDigit(c) || c == '.') {
+                break;
+            }
+        }
+        splitPoint += 1;
+
+        if (splitPoint > input.length()) return null;
+
+        String valueGroup = input.substring(0, splitPoint);
+        String unitGroup = input.substring(splitPoint).trim();
 
         Number value = Double.parseDouble(valueGroup);
         Unit<?> unit = UnitsApiService.getInstance().getUnit(unitGroup);

--- a/unit-api-core/src/test/groovy/com/raynigon/unit/api/core/io/DefaultQuantityReaderSpec.groovy
+++ b/unit-api-core/src/test/groovy/com/raynigon/unit/api/core/io/DefaultQuantityReaderSpec.groovy
@@ -5,11 +5,14 @@ import spock.lang.Unroll
 
 import static com.raynigon.unit.api.core.units.si.SISystemUnitsConstants.Celsius
 import static com.raynigon.unit.api.core.units.si.SISystemUnitsConstants.Metre
+import static com.raynigon.unit.api.core.units.si.SISystemUnitsConstants.Number
+import static com.raynigon.unit.api.core.units.si.SISystemUnitsConstants.CubicMetre
+import static com.raynigon.unit.api.core.units.si.SISystemUnitsConstants.Kilometre
 
 class DefaultQuantityReaderSpec extends Specification {
 
     @Unroll
-    def '#input is read as #output'() {
+    def '"#input" is read as #output'() {
         given:
         def reader = new DefaultQuantityReader()
 
@@ -21,9 +24,19 @@ class DefaultQuantityReaderSpec extends Specification {
 
         where:
         input    | output
+        "1" | Number(1)
+        "123" | Number(123)
         "1 m"    | Metre(1)
         "10 m"   | Metre(10)
         "10.2 m" | Metre(10.2)
         "1 ℃"    | Celsius(1)
+        "1℃"    | Celsius(1)
+        "0.1e-10 m" | Metre(0.1e-10)
+        "1234.5E10 m³" | CubicMetre(1.2345e13)
+        ".123 m" |  Metre(0.123)
+        "123m" | Metre(123)
+        "12. km" | Kilometre(12)
+        " " | null
+        "" | null
     }
 }


### PR DESCRIPTION
Opted for a loop to split the input instead of a regex. The regex would have become quite unwieldy otherweise.